### PR TITLE
Transfer ownership to maintainers of adrn/gala

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,4 +69,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - jni
+    - adrn
+    - mwcraig
+    - bsipocz


### PR DESCRIPTION
The Janelia FlyEM GALA project is abandoned and no longer needs to
maintain a conda-forge package.

References:

- https://github.com/adrn/gala
- https://github.com/janelia-flyem/gala
